### PR TITLE
fix return notification fireDate

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -77,6 +77,7 @@ class PushNotificationIOS {
   _isRemote: boolean;
   _remoteNotificationCompleteCallbackCalled: boolean;
   _threadID: string;
+  _fireDate: string | Date;
 
   static FetchResult: FetchResult = {
     NewData: 'UIBackgroundFetchResultNewData',
@@ -342,6 +343,7 @@ class PushNotificationIOS {
           this._category = notifVal.category;
           this._contentAvailable = notifVal['content-available'];
           this._threadID = notifVal['thread-id'];
+          this._fireDate = nativeNotif.fireDate;
         } else {
           this._data[notifKey] = notifVal;
         }
@@ -353,6 +355,7 @@ class PushNotificationIOS {
       this._alert = nativeNotif.alertBody;
       this._data = nativeNotif.userInfo;
       this._category = nativeNotif.category;
+      this._fireDate = nativeNotif.fireDate;
     }
   }
 

--- a/js/index.js
+++ b/js/index.js
@@ -343,7 +343,7 @@ class PushNotificationIOS {
           this._category = notifVal.category;
           this._contentAvailable = notifVal['content-available'];
           this._threadID = notifVal['thread-id'];
-          this._fireDate = nativeNotif.fireDate;
+          this._fireDate = notifVal.fireDate;
         } else {
           this._data[notifKey] = notifVal;
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
We need to have a` fireDate` in the response of the notification. It is impossible to figure out what date or time it was triggered without  `fireDate`
<!--
Explain the **motivation** for making this change: here are some points to help you:
I am working on IOS notification for a long time. I was this issue. 

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |


