### PR TITLE
chore: Use main thread for requesting notification permissions.

### DIFF
--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -315,7 +315,9 @@ RCT_EXPORT_METHOD(requestPermissions:(NSDictionary *)permissions
     if (error != NULL) {
       reject(@"-1", @"Error - Push authorization request failed.", error);
     } else {
-      [RCTSharedApplication() registerForRemoteNotifications];
+      dispatch_async(dispatch_get_main_queue(), ^(void){
+        [RCTSharedApplication() registerForRemoteNotifications];
+      });
       [UNUserNotificationCenter.currentNotificationCenter getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
         resolve(RCTPromiseResolveValueForUNNotificationSettings(settings));
       }];


### PR DESCRIPTION

# Summary
iOS throws a warning that registerForRemoteNotifications must be called
from the main thread only, this just wraps that call in a block to
ensure it always runs there, regardless of how the containing function
is called.


## Test Plan
Ran on a device under debug and saw the thread safety warning go away

### What's required for testing (prerequisites)?
Physical device

### What are the steps to reproduce (after prerequisites)?
Call the method below from a thread other than the main UI thread:
`
RCT_EXPORT_METHOD(requestPermissions:(NSDictionary *)permissions
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
