### PR TITLE
Handling local notification event for IOS 10+

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,20 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
 {
  [RNCPushNotificationIOS didFailToRegisterForRemoteNotificationsWithError:error];
 }
-// Required for the localNotification event.
+// IOS 10+ Required for localNotification event
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+didReceiveNotificationResponse:(UNNotificationResponse *)response
+         withCompletionHandler:(void (^)(void))completionHandler
+{
+  [RNCPushNotificationIOS didReceiveNotificationResponse:response];
+  completionHandler();
+}
+// IOS 4-10 Required for the localNotification event.
 - (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification
 {
  [RNCPushNotificationIOS didReceiveLocalNotification:notification];
 }
+
 ```
 
 Also, if not already present, at the top of the file:

--- a/example/ios/example/AppDelegate.m
+++ b/example/ios/example/AppDelegate.m
@@ -69,6 +69,14 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
 {
  [RNCPushNotificationIOS didReceiveLocalNotification:notification];
 }
+// IOS 10+ Required for local notification tapped event
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+didReceiveNotificationResponse:(UNNotificationResponse *)response
+         withCompletionHandler:(void (^)(void))completionHandler
+{
+  [RNCPushNotificationIOS didReceiveNotificationResponse:response];
+  completionHandler();
+}
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
 {

--- a/ios/RNCPushNotificationIOS.h
+++ b/ios/RNCPushNotificationIOS.h
@@ -19,6 +19,7 @@ typedef void (^RNCRemoteNotificationCallback)(UIBackgroundFetchResult result);
 + (void)didReceiveRemoteNotification:(NSDictionary *)notification;
 + (void)didReceiveRemoteNotification:(NSDictionary *)notification fetchCompletionHandler:(RNCRemoteNotificationCallback)completionHandler;
 + (void)didReceiveLocalNotification:(UILocalNotification *)notification;
++ (void)didReceiveNotificationResponse:(UNNotificationResponse *)response API_AVAILABLE(ios(10.0));
 + (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 #endif
 

--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -216,6 +216,13 @@ RCT_EXPORT_MODULE()
                                                     userInfo:RCTFormatLocalNotification(notification)];
 }
 
++ (void)didReceiveNotificationResponse:(UNNotificationResponse *)response
+API_AVAILABLE(ios(10.0)) {
+  [[NSNotificationCenter defaultCenter] postNotificationName:kLocalNotificationReceived
+                                                      object:self
+                                        userInfo:RCTFormatUNNotification(response.notification)];
+}
+
 - (void)handleLocalNotificationReceived:(NSNotification *)notification
 {
   [self sendEventWithName:@"localNotificationReceived" body:notification.userInfo];


### PR DESCRIPTION
# Summary

Closes https://github.com/react-native-community/push-notification-ios/issues/102https://github.com/react-native-community/push-notification-ios/issues/102

Local notification event is being managed by depreciated method. To make this work I have added support for new method used to handle local notification clicks.
I have implemented this feature in the same way the other local notification event was built.
This does not have any breaking changes as I implemented a new method that is used for IOS 10+

## Test Plan
- Local notification event should work on IOS 10+ with new `didReceiveNotificationResponse` and prior to IOS 10 using old `didReceiveLocalNotification` method.
- We need to ensure `localNotification` event is being fired when tapping local notification on a device with IOS 10.
- To support old versions of IOS this should also be tested on a device with older SDK to ensure the event is still being fired.

### What's required for testing (prerequisites)?
- Augment AppDelegate.m with new `didReceiveNotificationResponse` method mention in README.
- Set up app to present local notifications

### What are the steps to reproduce (after prerequisites)?
- Present a local notification and tap it
- Local notification event should fire with notification data

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x ] I have tested this on a device and a simulator
- [x ] I added the documentation in `README.md`
- [x ] I added a sample use of the API in the example project (`example/App.js`)
