### PR TITLE
Add userInteraction attr for user opened push

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,30 @@ to:
 import PushNotificationIOS from '@react-native-community/push-notification-ios';
 ```
 
+## How to determine push notification user click
+
+Receiving remote pushes has two common cases: user dismissed notification and user clicked notification. To have separate logic for each case you can use `notification.getData().userInteraction` to determine push notification user click:
+
+```js
+export const App = () => {
+  const [permissions, setPermissions] = useState({});
+
+  useEffect(() => {
+    PushNotificationIOS.addEventListener('notification', onRemoteNotification);
+  });
+
+  const onRemoteNotification = (notification) => {
+    const isClicked = notification.getData().userInteraction === 1
+
+    if (isClicked) {
+       // Navigate user to another screen
+    } else {
+       // Do something else with push notification
+    }
+  };
+}
+```
+
 # Reference
 
 ## Methods

--- a/example/App.js
+++ b/example/App.js
@@ -84,6 +84,16 @@ export const App = () => {
     });
   };
 
+  const sendSilentNotification = () => {
+    DeviceEventEmitter.emit('remoteNotificationReceived', {
+      remote: true,
+      aps: {
+        category: 'REACT_NATIVE',
+        'content-available': 1,
+      }
+    });
+  };
+
   const sendLocalNotification = () => {
     PushNotificationIOS.presentLocalNotification({
       alertTitle: 'Sample Title',
@@ -122,27 +132,42 @@ export const App = () => {
   };
 
   const onRemoteNotification = (notification) => {
+    const isClicked = notification.getData().userInteraction === 1
+
     const result = `
       Title:  ${notification.getTitle()};\n
       Message: ${notification.getMessage()};\n
       badge: ${notification.getBadgeCount()};\n
       sound: ${notification.getSound()};\n
       category: ${notification.getCategory()};\n
-      content-available: ${notification.getContentAvailable()}.`;
+      content-available: ${notification.getContentAvailable()};\n
+      Notification is clicked: ${isClicked}.`;
 
-    Alert.alert('Push Notification Received', result, [
-      {
-        text: 'Dismiss',
-        onPress: null,
-      },
-    ]);
+    if (notification.getTitle() == undefined) {
+      Alert.alert('Silent push notification Received', result, [
+        {
+          text: 'Send local push',
+          onPress: sendLocalNotification,
+        },
+      ]);
+    } else {
+       Alert.alert('Push Notification Received', result, [
+        {
+          text: 'Dismiss',
+          onPress: null,
+        },
+      ]);
+    }
   };
 
   const onLocalNotification = (notification) => {
+    const isClicked = notification.getData().userInteraction === 1
+
     Alert.alert(
       'Local Notification Received',
       `Alert title:  ${notification.getTitle()},
-      'Alert message:  ${notification.getMessage()}`,
+      'Alert message:  ${notification.getMessage()},
+      Notification is clicked: ${isClicked}.`,
       [
         {
           text: 'Dismiss',
@@ -170,6 +195,8 @@ export const App = () => {
         onPress={scheduleLocalNotification}
         label="Schedule fake local notification"
       />
+
+      <Button onPress={sendSilentNotification} label="Send fake silent notification" />
 
       <Button
         onPress={() => PushNotificationIOS.setApplicationIconBadgeNumber(42)}

--- a/example/App.js
+++ b/example/App.js
@@ -141,7 +141,7 @@ export const App = () => {
       sound: ${notification.getSound()};\n
       category: ${notification.getCategory()};\n
       content-available: ${notification.getContentAvailable()};\n
-      Notification is clicked: ${isClicked}.`;
+      Notification is clicked: ${String(isClicked)}.`;
 
     if (notification.getTitle() == undefined) {
       Alert.alert('Silent push notification Received', result, [
@@ -167,7 +167,7 @@ export const App = () => {
       'Local Notification Received',
       `Alert title:  ${notification.getTitle()},
       'Alert message:  ${notification.getMessage()},
-      Notification is clicked: ${isClicked}.`,
+      Notification is clicked: ${String(isClicked)}.`,
       [
         {
           text: 'Dismiss',

--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -127,6 +127,20 @@ static NSDictionary *RCTFormatUNNotification(UNNotification *notification)
   return formattedNotification;
 }
 
+API_AVAILABLE(ios(10.0))
+static NSDictionary *RCTFormatOpenedUNNotification(UNNotification *notification)
+{
+  NSMutableDictionary *formattedNotification = [RCTFormatUNNotification(notification) mutableCopy];
+  UNNotificationContent *content = notification.request.content;
+    
+  NSMutableDictionary *userInfo = [content.userInfo mutableCopy];
+  userInfo[@"userInteraction"] = [NSNumber numberWithInt:1];
+  
+  formattedNotification[@"userInfo"] = RCTNullIfNil(RCTJSONClean(userInfo));
+    
+  return formattedNotification;
+}
+
 #endif //TARGET_OS_TV / TARGET_OS_UIKITFORMAC
 
 RCT_EXPORT_MODULE()
@@ -222,7 +236,7 @@ RCT_EXPORT_MODULE()
 API_AVAILABLE(ios(10.0)) {
   [[NSNotificationCenter defaultCenter] postNotificationName:kLocalNotificationReceived
                                                       object:self
-                                        userInfo:RCTFormatUNNotification(response.notification)];
+                                        userInfo:RCTFormatOpenedUNNotification(response.notification)];
 }
 
 - (void)handleLocalNotificationReceived:(NSNotification *)notification


### PR DESCRIPTION
# Summary

In my app I need to run some JS code after user clicked on local notification. I didn't find any way to determine the moment user clicked on it.
This PR adds additional `userInteraction` attribute to userInfo for push messages that was opened by user.

If somebody approve this changes, I'll add an example.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |
