### PR TITLE
fix iOS build breaking

### DIFF
--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -96,7 +96,7 @@ static NSDictionary *RCTFormatLocalNotification(UILocalNotification *notificatio
   formattedLocalNotification[@"alertBody"] = RCTNullIfNil(notification.alertBody);
   formattedLocalNotification[@"applicationIconBadgeNumber"] = @(notification.applicationIconBadgeNumber);
   formattedLocalNotification[@"category"] = RCTNullIfNil(notification.category);
-  formattedLocalNotification[@"repeatInterval"] = RCTNullIfNil(notification.repeatInterval);
+  formattedLocalNotification[@"repeatInterval"] = @(notification.repeatInterval);
   formattedLocalNotification[@"soundName"] = RCTNullIfNil(notification.soundName);
   formattedLocalNotification[@"userInfo"] = RCTNullIfNil(RCTJSONClean(notification.userInfo));
   formattedLocalNotification[@"remote"] = @NO;


### PR DESCRIPTION
Fixes `Incompatible operand types ('NSUInteger' (aka 'unsigned long') and 'id')` on repeat interval.

Looks like my CocoaPods were cached when testing. With cleaned build cache current version doesn't build. My bad...

This needs to be released as a hotfix 😞 
@Naturalclar 