### PR TITLE
Added support for checking if lockScreen and notificationCenter settings are enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,8 @@ See what push permissions are currently enabled.
 - `alert` :boolean
 - `badge` :boolean
 - `sound` :boolean
+- `lockScreen` :boolean
+- `notificationCenter` :boolean
 
 ---
 

--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -342,7 +342,7 @@ RCT_EXPORT_METHOD(abandonPermissions)
 RCT_EXPORT_METHOD(checkPermissions:(RCTResponseSenderBlock)callback)
 {
   if (RCTRunningInAppExtension()) {
-    callback(@[RCTSettingsDictForUNNotificationSettings(NO, NO, NO)]);
+    callback(@[RCTSettingsDictForUNNotificationSettings(NO, NO, NO, NO, NO)]);
     return;
   }
   
@@ -354,12 +354,14 @@ RCT_EXPORT_METHOD(checkPermissions:(RCTResponseSenderBlock)callback)
 static inline NSDictionary *RCTPromiseResolveValueForUNNotificationSettings(UNNotificationSettings* _Nonnull settings) {
   return RCTSettingsDictForUNNotificationSettings(settings.alertSetting == UNNotificationSettingEnabled,
                                                   settings.badgeSetting == UNNotificationSettingEnabled,
-                                                  settings.soundSetting == UNNotificationSettingEnabled);
+                                                  settings.soundSetting == UNNotificationSettingEnabled,
+                                                  settings.lockScreenSetting == UNNotificationSettingEnabled,
+                                                  settings.notificationCenterSetting == UNNotificationSettingEnabled);
   }
 
-static inline NSDictionary *RCTSettingsDictForUNNotificationSettings(BOOL alert, BOOL badge, BOOL sound) {
-  return @{@"alert": @(alert), @"badge": @(badge), @"sound": @(sound)};
-  }	
+static inline NSDictionary *RCTSettingsDictForUNNotificationSettings(BOOL alert, BOOL badge, BOOL sound, BOOL lockScreen, BOOL notificationCenter) {
+  return @{@"alert": @(alert), @"badge": @(badge), @"sound": @(sound), @"lockScreen": @(lockScreen), @"notificationCenter": @(notificationCenter)};
+  }
 
 
 RCT_EXPORT_METHOD(presentLocalNotification:(UILocalNotification *)notification)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

I was working on a project and needed access to know if notifications were enabled for `lockScreen` and `notificationCenter` when firing `checkPermissions()`.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

To test fire `checkPermissions()` and you should get an updated object that includes `lockScreen` and `notificationCenter`. 

Alternatively, you can also run the `/example` and press "show enabled permissions".

Before this commit:
```
{
    "alert": true,
    "badge": true,
    "sound": true,
}
```

After commit:
```
{
    "alert": true,
    "badge": true,
    "sound": true,
    "lockScreen": true, 
    "notificationCenter": true,
}
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
