### PR TITLE
Add method getTitle to get notification title in JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,9 @@ yarn add @react-native-community/push-notification-ios
 
 ## Link
 
-
-
 ### React Native v0.60+
 
- The package is [automatically linked](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) when building the app. All you need to do is:
+The package is [automatically linked](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) when building the app. All you need to do is:
 
 ```bash
 npx pod-install
@@ -32,7 +30,7 @@ For android, the package will be linked automatically on build.
 <details>
  <summary>For React Native version 0.59 or older</summary>
 
-### React Native <= v0.59 
+### React Native <= v0.59
 
 ```bash
 react-native link @react-native-community/push-notification-ios
@@ -40,16 +38,16 @@ react-native link @react-native-community/push-notification-ios
 
 - upgrading to `react-native >= 0.60`
 
- First, unlink the library. Then follow the instructions above.
+First, unlink the library. Then follow the instructions above.
 
- ```bash
- react-native unlink @react-native-community/push-notification-ios
- ```
+```bash
+react-native unlink @react-native-community/push-notification-ios
+```
 
 - manual linking
 
- If you don't want to use the methods above, you can always [link the library manually](./docs/manual-linking.md).
- 
+If you don't want to use the methods above, you can always [link the library manually](./docs/manual-linking.md).
+
 </details>
 
 ### Add Capabilities : Background Mode - Remote Notifications
@@ -57,17 +55,18 @@ react-native link @react-native-community/push-notification-ios
 Go into your MyReactProject/ios dir and open MyProject.xcworkspace workspace.
 Select the top project "MyProject" and select the "Signing & Capabilities" tab.
 Add a 2 new Capabilities using "+" button:
+
 - `Background Mode` capability and tick `Remote Notifications`.
 - `Push Notifications` capability
-
 
 ### Augment `AppDelegate`
 
 Finally, to enable support for `notification` and `register` events you need to augment your AppDelegate.
 
-### Update `AppDelegate.h`	
+### Update `AppDelegate.h`
 
 At the top of the file:
+
 ```objective-c
 #import <UserNotifications/UNUserNotificationCenter.h>
 ```
@@ -77,6 +76,7 @@ Then, add the 'UNUserNotificationCenterDelegate' to protocols:
 ```objective-c
 @interface AppDelegate : UIResponder <UIApplicationDelegate, RCTBridgeDelegate, UNUserNotificationCenterDelegate>
 ```
+
 ### Update `AppDelegate.m`
 
 At the top of the file:
@@ -151,15 +151,14 @@ And then in your AppDelegate implementation, add the following:
 This module was created when the PushNotificationIOS was split out from the core of React Native. To migrate to this module you need to follow the installation instructions above and then change you imports from:
 
 ```js
-import { PushNotificationIOS } from "react-native";
+import {PushNotificationIOS} from 'react-native';
 ```
 
 to:
 
 ```js
-import PushNotificationIOS from "@react-native-community/push-notification-ios";
+import PushNotificationIOS from '@react-native-community/push-notification-ios';
 ```
-
 
 # Reference
 
@@ -520,6 +519,16 @@ getAlert();
 ```
 
 Gets the notification's main message from the `aps` object
+
+---
+
+### `getTitle()`
+
+```jsx
+getTitle();
+```
+
+Gets the notification's title from the `aps` object
 
 ---
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,7 +32,7 @@ export interface PushNotification {
   /**
    * Gets the notification's title from the `aps` object
    */
-  getTitle(): string | Record<string, any>;
+  getTitle(): string;
 
   /**
    * Gets the content-available number from the `aps` object

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,11 @@ export interface PushNotification {
   getAlert(): string | Record<string, any>;
 
   /**
+   * Gets the notification's title from the `aps` object
+   */
+  getTitle(): string | Record<string, any>;
+
+  /**
    * Gets the content-available number from the `aps` object
    */
   getContentAvailable(): number;

--- a/js/index.js
+++ b/js/index.js
@@ -384,7 +384,7 @@ class PushNotificationIOS {
         const notifVal = nativeNotif[notifKey];
         if (notifKey === 'aps') {
           this._alert = notifVal.alert;
-          this._title = notifVal.alertTitle;
+          this._title = notifVal?.alertTitle;
           this._sound = notifVal.sound;
           this._badgeCount = notifVal.badge;
           this._category = notifVal.category;
@@ -400,7 +400,7 @@ class PushNotificationIOS {
       this._badgeCount = nativeNotif.applicationIconBadgeNumber;
       this._sound = nativeNotif.soundName;
       this._alert = nativeNotif.alertBody;
-      this._title = nativeNotif.alertTitle;
+      this._title = nativeNotif?.alertTitle;
       this._data = nativeNotif.userInfo;
       this._category = nativeNotif.category;
       this._fireDate = nativeNotif.fireDate;

--- a/js/index.js
+++ b/js/index.js
@@ -77,7 +77,6 @@ class PushNotificationIOS {
   _isRemote: boolean;
   _remoteNotificationCompleteCallbackCalled: boolean;
   _threadID: string;
-  _fireDate: string | Date;
 
   static FetchResult: FetchResult = {
     NewData: 'UIBackgroundFetchResultNewData',
@@ -384,12 +383,12 @@ class PushNotificationIOS {
         const notifVal = nativeNotif[notifKey];
         if (notifKey === 'aps') {
           this._alert = notifVal.alert;
+          this._title = notifVal.alertTitle;
           this._sound = notifVal.sound;
           this._badgeCount = notifVal.badge;
           this._category = notifVal.category;
           this._contentAvailable = notifVal['content-available'];
           this._threadID = notifVal['thread-id'];
-          this._fireDate = notifVal.fireDate;
         } else {
           this._data[notifKey] = notifVal;
         }
@@ -399,9 +398,9 @@ class PushNotificationIOS {
       this._badgeCount = nativeNotif.applicationIconBadgeNumber;
       this._sound = nativeNotif.soundName;
       this._alert = nativeNotif.alertBody;
+      this._title = nativeNotif.alertTitle;
       this._data = nativeNotif.userInfo;
       this._category = nativeNotif.category;
-      this._fireDate = nativeNotif.fireDate;
     }
   }
 
@@ -464,6 +463,14 @@ class PushNotificationIOS {
    */
   getAlert(): ?string | ?Object {
     return this._alert;
+  }
+
+  /**
+   * Gets the notification's title from the `aps` object
+   *
+   */
+  getTitle(): ?string | ?Object {
+    return this._title;
   }
 
   /**

--- a/js/index.js
+++ b/js/index.js
@@ -69,6 +69,7 @@ export type PushNotificationEventName = $Keys<{
 class PushNotificationIOS {
   _data: Object;
   _alert: string | Object;
+  _title: string;
   _sound: string;
   _category: string;
   _contentAvailable: ContentAvailable;

--- a/js/index.js
+++ b/js/index.js
@@ -77,6 +77,7 @@ class PushNotificationIOS {
   _isRemote: boolean;
   _remoteNotificationCompleteCallbackCalled: boolean;
   _threadID: string;
+  _fireDate: string | Date;
 
   static FetchResult: FetchResult = {
     NewData: 'UIBackgroundFetchResultNewData',

--- a/js/index.js
+++ b/js/index.js
@@ -389,6 +389,7 @@ class PushNotificationIOS {
           this._category = notifVal.category;
           this._contentAvailable = notifVal['content-available'];
           this._threadID = notifVal['thread-id'];
+          this._fireDate = notifVal.fireDate;
         } else {
           this._data[notifKey] = notifVal;
         }
@@ -401,6 +402,7 @@ class PushNotificationIOS {
       this._title = nativeNotif.alertTitle;
       this._data = nativeNotif.userInfo;
       this._category = nativeNotif.category;
+      this._fireDate = nativeNotif.fireDate;
     }
   }
 


### PR DESCRIPTION
# Summary

Currently, we can access notification's `alertBody` by using `getAlert()` or `getMessage()`, but there is no method for getting the `alertTitle`in JavaScript side. This PR adds that missing piece. 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
