### PR TITLE
Add authorizationStatus in permissions object

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,9 @@ See what push permissions are currently enabled.
 - `sound` :boolean
 - `lockScreen` :boolean
 - `notificationCenter` :boolean
+- `authorizationStatus` :AuthorizationStatus
 
+  For a list of possible values of `authorizationStatus`, see `PushNotificationIOS.AuthorizationStatus`. For their meanings, refer to https://developer.apple.com/documentation/usernotifications/unauthorizationstatus
 ---
 
 ### `getInitialNotification()`

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,13 @@ export interface FetchResult {
   ResultFailed: 'UIBackgroundFetchResultFailed';
 }
 
+export interface AuthorizationStatus {
+  UNAuthorizationStatusNotDetermined: 0;
+  UNAuthorizationStatusDenied: 1;
+  UNAuthorizationStatusAuthorized: 2;
+  UNAuthorizationStatusProvisional: 3;
+}
+
 export interface PushNotification {
   /**
    * An alias for `getAlert` to get the notification's main message string
@@ -148,6 +155,9 @@ export interface PushNotificationPermissions {
   alert?: boolean;
   badge?: boolean;
   sound?: boolean;
+  lockScreen?: boolean;
+  notificationCenter?: boolean;
+  authorizationStatus?: AuthorizationStatus;
 }
 
 export type PushNotificationEventName =
@@ -168,6 +178,11 @@ export interface PushNotificationIOSStatic {
    * For a list of possible values, see `PushNotificationIOS.FetchResult`.
    */
   FetchResult: FetchResult;
+  /**
+   * Authorization status of notification settings 
+   * For a list of possible values, see `PushNotificationIOS.AuthorizationStatus`.
+   */
+  AuthorizationStatus: AuthorizationStatus;
   /**
    * Schedules the localNotification for immediate presentation.
    * details is an object containing:

--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -356,7 +356,7 @@ RCT_EXPORT_METHOD(abandonPermissions)
 RCT_EXPORT_METHOD(checkPermissions:(RCTResponseSenderBlock)callback)
 {
   if (RCTRunningInAppExtension()) {
-    callback(@[RCTSettingsDictForUNNotificationSettings(NO, NO, NO, NO, NO)]);
+    callback(@[RCTSettingsDictForUNNotificationSettings(NO, NO, NO, NO, NO, UNAuthorizationStatusNotDetermined)]);
     return;
   }
   
@@ -370,11 +370,12 @@ static inline NSDictionary *RCTPromiseResolveValueForUNNotificationSettings(UNNo
                                                   settings.badgeSetting == UNNotificationSettingEnabled,
                                                   settings.soundSetting == UNNotificationSettingEnabled,
                                                   settings.lockScreenSetting == UNNotificationSettingEnabled,
-                                                  settings.notificationCenterSetting == UNNotificationSettingEnabled);
+                                                  settings.notificationCenterSetting == UNNotificationSettingEnabled,
+                                                  settings.authorizationStatus);
   }
 
-static inline NSDictionary *RCTSettingsDictForUNNotificationSettings(BOOL alert, BOOL badge, BOOL sound, BOOL lockScreen, BOOL notificationCenter) {
-  return @{@"alert": @(alert), @"badge": @(badge), @"sound": @(sound), @"lockScreen": @(lockScreen), @"notificationCenter": @(notificationCenter)};
+static inline NSDictionary *RCTSettingsDictForUNNotificationSettings(BOOL alert, BOOL badge, BOOL sound, BOOL lockScreen, BOOL notificationCenter, UNAuthorizationStatus authorizationStatus) {
+  return @{@"alert": @(alert), @"badge": @(badge), @"sound": @(sound), @"lockScreen": @(lockScreen), @"notificationCenter": @(notificationCenter), @"authorizationStatus": @(authorizationStatus)};
   }
 
 

--- a/js/index.js
+++ b/js/index.js
@@ -32,6 +32,13 @@ export type FetchResult = {
   ResultFailed: string,
 };
 
+export type AuthorizationStatus = {
+  UNAuthorizationStatusNotDetermined: Number;
+  UNAuthorizationStatusDenied: Number;
+  UNAuthorizationStatusAuthorized: Number;
+  UNAuthorizationStatusProvisional: Number;
+}
+
 /**
  * An event emitted by PushNotificationIOS.
  */
@@ -84,6 +91,13 @@ class PushNotificationIOS {
     NewData: 'UIBackgroundFetchResultNewData',
     NoData: 'UIBackgroundFetchResultNoData',
     ResultFailed: 'UIBackgroundFetchResultFailed',
+  };
+  
+  static AuthorizationStatus: AuthorizationStatus = {
+    UNAuthorizationStatusNotDetermined: 0,
+    UNAuthorizationStatusDenied: 1,
+    UNAuthorizationStatusAuthorized: 2,
+    UNAuthorizationStatusProvisional: 3,
   };
 
   /**

--- a/js/index.js
+++ b/js/index.js
@@ -33,11 +33,11 @@ export type FetchResult = {
 };
 
 export type AuthorizationStatus = {
-  UNAuthorizationStatusNotDetermined: Number;
-  UNAuthorizationStatusDenied: Number;
-  UNAuthorizationStatusAuthorized: Number;
-  UNAuthorizationStatusProvisional: Number;
-}
+  UNAuthorizationStatusNotDetermined: 0,
+  UNAuthorizationStatusDenied: 1,
+  UNAuthorizationStatusAuthorized: 2,
+  UNAuthorizationStatusProvisional: 3,
+};
 
 /**
  * An event emitted by PushNotificationIOS.
@@ -92,7 +92,7 @@ class PushNotificationIOS {
     NoData: 'UIBackgroundFetchResultNoData',
     ResultFailed: 'UIBackgroundFetchResultFailed',
   };
-  
+
   static AuthorizationStatus: AuthorizationStatus = {
     UNAuthorizationStatusNotDetermined: 0,
     UNAuthorizationStatusDenied: 1,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
I need to know whether user has determined the notification permission (i.e. whether user has went through the "Don't Allow/Allow' permission modal)
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?
Run the `/example` and press "show enabled permissions".

Before this commit:
```
{
    "alert": true,
    "badge": true,
    "sound": true,
    "lockScreen": true, 
    "notificationCenter": true,
}
```
After commit:
```
{
    "alert": true,
    "badge": true,
    "sound": true,
    "lockScreen": true, 
    "notificationCenter": true,
    "authorizationStatus": 0,
}
```
## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
